### PR TITLE
Lyapunov derivative sample loss for a batch of data

### DIFF
--- a/robust_value_approx/lyapunov.py
+++ b/robust_value_approx/lyapunov.py
@@ -251,10 +251,10 @@ class LyapunovHybridLinearSystem:
         assert(x_equilibrium.shape == (self.system.x_dim,))
         assert(isinstance(V_rho, float))
         assert(isinstance(margin, float))
-        return torch.mean(torch.nn.HingeEmbeddingLoss(margin=margin)(
+        return torch.nn.HingeEmbeddingLoss(margin=margin)(
             self.lyapunov_value(
                 relu_model, state_samples, x_equilibrium, V_rho,
-                relu_at_equilibrium), torch.tensor(-1.)))
+                relu_at_equilibrium), torch.tensor(-1.))
 
     def add_lyapunov_bounds_constraint(
         self, lyapunov_lower, lyapunov_upper, milp, a_relu, b_relu, V_rho,
@@ -461,7 +461,7 @@ class LyapunovDiscreteTimeHybridSystem(LyapunovHybridLinearSystem):
         ReLU(x) - ReLU(x*) + ρ|x-x*|₁
         @param V_rho ρ in the Lyapunov function.
         @param epsilon ε in the Lyapunov function.
-        @param state_samples The sampled state x̅[n], state_samples[i] is the 
+        @param state_samples The sampled state x̅[n], state_samples[i] is the
         i'th sample x̅ⁱ[n]
         @param x_equilibrium x*.
         @param margin We might want to shift the margin for the Lyapunov
@@ -479,7 +479,7 @@ class LyapunovDiscreteTimeHybridSystem(LyapunovHybridLinearSystem):
             mode = self.system.mode(state_samples[i])
             if mode is None:
                 raise Exception(
-                    f"lyapunov_derivative_loss_at_samples: the input "+
+                    f"lyapunov_derivative_loss_at_samples: the input " +
                     f"state_sample {state_samples[i]}" +
                     f" is not in any mode of the hybrid system.")
             state_next[i] = self.system.step_forward(state_samples[i], mode)
@@ -501,7 +501,7 @@ class LyapunovDiscreteTimeHybridSystem(LyapunovHybridLinearSystem):
         ReLU(x) - ReLU(x*) + ρ|x-x*|₁
         @param V_rho ρ in the Lyapunov function.
         @param epsilon ε in the Lyapunov function.
-        @param state_samples The sampled state x̅[n], state_samples[i] is the 
+        @param state_samples The sampled state x̅[n], state_samples[i] is the
         i'th sample x̅ⁱ[n]
         @param state_next The next state x̅[n+1], state_next[i] is the next
         state for the i'th sample x̅ⁱ[n+1]

--- a/robust_value_approx/test/test_lyapunov.py
+++ b/robust_value_approx/test/test_lyapunov.py
@@ -1401,10 +1401,6 @@ class TestLyapunovContinuousTimeHybridSystem(unittest.TestCase):
         relu1 = setup_relu(torch.float64)
         relu2 = setup_leaky_relu(torch.float64)
         for relu in (relu1, relu2):
-            num_full_connected_layers = int(len(relu) / 2) if \
-                isinstance(relu[-1], torch.nn.ReLU) or \
-                isinstance(relu[-1], torch.nn.LeakyReLU) else \
-                int((len(relu)-1)/2)
             for system, x_equilibrium in (
                 (self.system1, self.x_equilibrium1),
                     (self.system2, self.x_equilibrium2)):

--- a/robust_value_approx/test/train_discrete_1d_lyapunov.py
+++ b/robust_value_approx/test/train_discrete_1d_lyapunov.py
@@ -44,9 +44,9 @@ def setup_relu():
 
 def plot_relu(relu, system, V_rho, x_equilibrium):
     num_samples = 1001
-    x_samples = list(torch.linspace(-1, 1, num_samples).type(torch.float64).
-                     reshape((-1, 1)))
-    x_next = [system.step_forward(x) for x in x_samples]
+    x_samples = torch.linspace(-1, 1, num_samples).type(torch.float64).\
+        reshape((-1, 1))
+    x_next = torch.stack([system.step_forward(x) for x in x_samples])
     with torch.no_grad():
         V = torch.zeros(num_samples)
         V_next = torch.zeros(num_samples)
@@ -77,8 +77,8 @@ if __name__ == "__main__":
     relu = setup_relu()
     V_rho = 0.1
     x_equilibrium = torch.tensor([0], dtype=torch.float64)
-    state_samples_all = list(torch.linspace(-1, 1, 20).type(torch.float64).
-                             reshape((-1, 1)))
+    state_samples_all = torch.linspace(-1, 1, 20).type(torch.float64).\
+        reshape((-1, 1))
     train_value_approximator = train_lyapunov.TrainValueApproximator()
     train_value_approximator.max_epochs = 500
     train_value_approximator.convergence_tolerance = 0.001

--- a/robust_value_approx/test/train_discrete_linear_system_toy_lyapunov.py
+++ b/robust_value_approx/test/train_discrete_linear_system_toy_lyapunov.py
@@ -59,7 +59,7 @@ def setup_state_samples_all(mesh_size, x_equilibrium, theta):
             state_samples[i * samples_x.shape[1] + j] = R @ torch.tensor(
                 [samples_x[i, j], samples_y[i, j]], dtype=dtype) +\
                     x_equilibrium
-    return state_samples
+    return torch.stack(state_samples, dim=0)
 
 
 def plot_relu(relu, system, V_rho, x_equilibrium, mesh_size, theta):


### PR DESCRIPTION
Similar to #120, now compute the lyapunov derivative loss for a batch of data using pytorch function instead of using for loop. Now computing the loss for a batch of data takes 40% of time compared to the previous implementation.