### PR TITLE
Add ReLUSecondOrderSystemGivenEquilibrium class.

### DIFF
--- a/neural_network_lyapunov/test/test_relu_system.py
+++ b/neural_network_lyapunov/test/test_relu_system.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 
 import neural_network_lyapunov.relu_system as relu_system
 import neural_network_lyapunov.gurobi_torch_mip as gurobi_torch_mip
+import neural_network_lyapunov.utils as utils
 
 
 def setup_relu_dyn(dtype, params=None):
@@ -94,30 +95,33 @@ class TestAutonomousReluSystem(unittest.TestCase):
             check_transition(x0)
 
 
-def check_mixed_integer_constraints(tester, dut, autonomous=True):
+def check_mixed_integer_constraints(tester, dut, x_val, u_val, autonomous):
+    """
+    Solve the MIP by constraining x[n] and u[n], the solution x[n+1]
+    should match with calling step_forward(x[n], u[n]).
+    """
     mip_cnstr_return = dut.mixed_integer_constraints()
     tester.assertIsNone(mip_cnstr_return.Aout_binary)
 
-    def check_transition(x_val, u_val=None):
-        milp = gurobi_torch_mip.GurobiTorchMILP(dut.dtype)
-        x = milp.addVars(
-            dut.x_dim, lb=-gurobipy.GRB.INFINITY,
-            vtype=gurobipy.GRB.CONTINUOUS, name="x")
-        if not autonomous:
-            u = milp.addVars(
-                dut.u_dim, lb=-gurobipy.GRB.INFINITY,
-                vtype=gurobipy.GRB.CONTINUOUS, name="u")
-            s, gamma = milp.add_mixed_integer_linear_constraints(
-                mip_cnstr_return, x+u, None, "s", "gamma",
-                "relu_dynamics_ineq", "relu_dynamics_eq", "")
-        else:
-            s, gamma = milp.add_mixed_integer_linear_constraints(
-                mip_cnstr_return, x, None, "s", "gamma",
-                "relu_dynamics_ineq", "relu_dynamics_eq", "")
-        for i in range(dut.x_dim):
-            milp.addLConstr(
-                [torch.tensor([1.], dtype=dut.dtype)], [[x[i]]],
-                sense=gurobipy.GRB.EQUAL, rhs=x_val[i])
+    milp = gurobi_torch_mip.GurobiTorchMILP(dut.dtype)
+    x = milp.addVars(
+        dut.x_dim, lb=-gurobipy.GRB.INFINITY,
+        vtype=gurobipy.GRB.CONTINUOUS, name="x")
+    if not autonomous:
+        u = milp.addVars(
+            dut.u_dim, lb=-gurobipy.GRB.INFINITY,
+            vtype=gurobipy.GRB.CONTINUOUS, name="u")
+        s, gamma = milp.add_mixed_integer_linear_constraints(
+            mip_cnstr_return, x+u, None, "s", "gamma",
+            "relu_dynamics_ineq", "relu_dynamics_eq", "")
+    else:
+        s, gamma = milp.add_mixed_integer_linear_constraints(
+            mip_cnstr_return, x, None, "s", "gamma",
+            "relu_dynamics_ineq", "relu_dynamics_eq", "")
+    for i in range(dut.x_dim):
+        milp.addLConstr(
+            [torch.tensor([1.], dtype=dut.dtype)], [[x[i]]],
+            sense=gurobipy.GRB.EQUAL, rhs=x_val[i])
         if not autonomous:
             for i in range(dut.u_dim):
                 milp.addLConstr(
@@ -133,31 +137,13 @@ def check_mixed_integer_constraints(tester, dut, autonomous=True):
         nn_input = x_val if autonomous else torch.cat((x_val, u_val))
         if mip_cnstr_return.Aout_input is not None:
             x_next_val += mip_cnstr_return.Aout_input @ nn_input
-        if autonomous:
-            x_next_val_expected = dut.step_forward(x_val)
-        else:
-            x_next_val_expected = dut.step_forward(x_val, u_val)
-        np.testing.assert_array_almost_equal(
-            x_next_val.detach().numpy(),
-            x_next_val_expected.detach().numpy(), decimal=5)
-
     if autonomous:
-        check_transition(
-            torch.tensor([0.2, 0.5, .2], dtype=dut.dtype))
-        check_transition(
-            torch.tensor([1.2, 0.5, .1], dtype=dut.dtype))
-        check_transition(
-            torch.tensor([-1.2, 0.3, .3], dtype=dut.dtype))
+        x_next_val_expected = dut.step_forward(x_val)
     else:
-        check_transition(
-            torch.tensor([0.2, 0.5], dtype=dut.dtype),
-            u_val=torch.tensor([0.1], dtype=dut.dtype))
-        check_transition(
-            torch.tensor([1.2, 0.5], dtype=dut.dtype),
-            u_val=torch.tensor([0.1], dtype=dut.dtype))
-        check_transition(
-            torch.tensor([-1.2, 0.3], dtype=dut.dtype),
-            u_val=torch.tensor([0.5], dtype=dut.dtype))
+        x_next_val_expected = dut.step_forward(x_val, u_val)
+    np.testing.assert_array_almost_equal(
+        x_next_val.detach().numpy(),
+        x_next_val_expected.detach().numpy(), decimal=5)
 
 
 class TestReLUSystem(unittest.TestCase):
@@ -191,7 +177,17 @@ class TestReLUSystem(unittest.TestCase):
         self.assertEqual(dut.x_dim, 2)
         self.assertEqual(dut.u_dim, 1)
 
-        check_mixed_integer_constraints(self, dut, autonomous=False)
+        result = dut.mixed_integer_constraints()
+        self.assertIsNone(result.Aout_input)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([0.2, 0.5], dtype=dut.dtype),
+            u_val=torch.tensor([0.1], dtype=dut.dtype), autonomous=False)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([1.2, 0.5], dtype=dut.dtype),
+            u_val=torch.tensor([0.1], dtype=dut.dtype), autonomous=False)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([-1.2, 0.3], dtype=dut.dtype),
+            u_val=torch.tensor([0.5], dtype=dut.dtype), autonomous=False)
 
     def test_possible_dx(self):
         dut = self.construct_relu_system_example()
@@ -238,7 +234,116 @@ class TestReLUSystemGivenEquilibrium(unittest.TestCase):
 
         self.assertEqual(dut.x_dim, 2)
         self.assertEqual(dut.u_dim, 1)
-        check_mixed_integer_constraints(self, dut, autonomous=False)
+        result = dut.mixed_integer_constraints()
+        self.assertIsNone(result.Aout_input)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([0.2, 0.5], dtype=dut.dtype),
+            u_val=torch.tensor([0.1], dtype=dut.dtype), autonomous=False)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([1.2, 0.5], dtype=dut.dtype),
+            u_val=torch.tensor([0.1], dtype=dut.dtype), autonomous=False)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([-1.2, 0.3], dtype=dut.dtype),
+            u_val=torch.tensor([0.5], dtype=dut.dtype), autonomous=False)
+
+    def test_step_forward(self):
+        dut = self.construct_relu_system_example()
+
+        # step_forward evaluated at the equilibrium should return the
+        # equilibrium state.
+        np.testing.assert_allclose(dut.step_forward(
+            dut.x_equilibrium, dut.u_equilibrium).detach().numpy(),
+            dut.x_equilibrium.detach().numpy())
+
+        def check(x, u):
+            x_next_expected = dut.dynamics_relu(torch.cat((x, u))) -\
+                dut.dynamics_relu(torch.cat((
+                    dut.x_equilibrium, dut.u_equilibrium))) + dut.x_equilibrium
+            x_next = dut.step_forward(x, u)
+            np.testing.assert_allclose(
+                x_next_expected.detach().numpy(), x_next.detach().numpy())
+        check(torch.tensor([0.2, 0.6], dtype=dut.dtype),
+              torch.tensor([0.5], dtype=dut.dtype))
+        check(torch.tensor([-0.2, 0.6], dtype=dut.dtype),
+              torch.tensor([0.9], dtype=dut.dtype))
+        check(torch.tensor([-1.2, 1.6], dtype=dut.dtype),
+              torch.tensor([-.2], dtype=dut.dtype))
+
+
+class TestReLUSecondOrderSystemGivenEquilibrium(unittest.TestCase):
+    def construct_relu_system_example(self):
+        # Construct a ReLU system with nq = 2, nv = 2 and nu = 1
+        self.dtype = torch.float64
+        dynamics_relu = utils.setup_relu(
+            (5, 5, 2), params=None, negative_slope=0.01, bias=True,
+            dtype=self.dtype)
+        dynamics_relu[0].weight.data = torch.tensor(
+            [[0.1, 0.2, 0.3, 0.4, -0.1], [0.5, -0.2, 0.4, 0.3, -0.2],
+             [0.1, 0.3, -1.2, 1.2, -0.8], [1.5, 0.3, 0.3, -0.5, -2.1],
+             [0.2, 1.5, 0.1, 0.9, 1.1]], dtype=self.dtype)
+        dynamics_relu[0].bias.data = torch.tensor(
+            [0.1, -1.2, 0.3, 0.2, -0.5], dtype=self.dtype)
+        dynamics_relu[2].weight.data = torch.tensor(
+            [[0.1, -2.3, 1.5, 0.4, 0.2], [0.1, -1.2, -1.3, 0.3, 0.8]],
+            dtype=self.dtype)
+        dynamics_relu[2].bias.data = torch.tensor(
+            [0.2, -1.4], dtype=self.dtype)
+
+        x_lo = torch.tensor([-2, -2, -5, -5], dtype=self.dtype)
+        x_up = torch.tensor([2, 2, 5, 5], dtype=self.dtype)
+        u_lo = torch.tensor([-5], dtype=self.dtype)
+        u_up = torch.tensor([5], dtype=self.dtype)
+        q_equilibrium = torch.tensor([0.5, 0.3], dtype=self.dtype)
+        u_equilibrium = torch.tensor([0.4], dtype=self.dtype)
+        dt = 0.01
+        dut = relu_system.ReLUSecondOrderSystemGivenEquilibrium(
+            self.dtype, x_lo, x_up, u_lo, u_up, dynamics_relu, q_equilibrium,
+            u_equilibrium, dt)
+        return dut
+
+    def test_mixed_integer_constraints(self):
+        dut = self.construct_relu_system_example()
+        check_mixed_integer_constraints(
+            self, dut,
+            x_val=torch.tensor([0.2, 0.5, 0.4, 0.3], dtype=dut.dtype),
+            u_val=torch.tensor([0.1], dtype=dut.dtype), autonomous=False)
+        check_mixed_integer_constraints(
+            self, dut,
+            x_val=torch.tensor([1.2, 0.5, 0.3, -0.4], dtype=dut.dtype),
+            u_val=torch.tensor([0.1], dtype=dut.dtype), autonomous=False)
+        check_mixed_integer_constraints(
+            self, dut,
+            x_val=torch.tensor([-1.2, 0.3, 0.8, -0.7], dtype=dut.dtype),
+            u_val=torch.tensor([0.5], dtype=dut.dtype), autonomous=False)
+
+    def test_step_forward(self):
+        dut = self.construct_relu_system_example()
+
+        # step_forward evaluated at the equilibrium should return the
+        # equilibrium state.
+        np.testing.assert_allclose(dut.step_forward(
+            dut.x_equilibrium, dut.u_equilibrium).detach().numpy(),
+            dut.x_equilibrium.detach().numpy())
+
+        def check(x, u):
+            with torch.no_grad():
+                q = x[:dut.nq]
+                v = x[dut.nq:]
+                v_next = dut.dynamics_relu(torch.cat((x, u))) -\
+                    dut.dynamics_relu(torch.cat((
+                        dut.x_equilibrium, dut.u_equilibrium)))
+                q_next = q + (v + v_next) / 2 * dut.dt
+                x_next_expected = torch.cat((q_next, v_next))
+                np.testing.assert_allclose(
+                    dut.step_forward(x, u).detach().numpy(),
+                    x_next_expected.detach().numpy())
+
+        check(torch.tensor([0.5, 0.9, -0.1, -1.2], dtype=self.dtype),
+              torch.tensor([1.5], dtype=self.dtype))
+        check(torch.tensor([1.5, 2.9, -2.4, -0.7], dtype=self.dtype),
+              torch.tensor([2.5], dtype=self.dtype))
+        check(torch.tensor([0.2, -.9, -1.4, 0.1], dtype=self.dtype),
+              torch.tensor([-2.1], dtype=self.dtype))
 
 
 class TestAutonomousReLUSystemGivenEquilibrium(unittest.TestCase):
@@ -272,7 +377,17 @@ class TestAutonomousReLUSystemGivenEquilibrium(unittest.TestCase):
         dut, _ = self.construct_relu_system_example()
 
         self.assertEqual(dut.x_dim, 3)
-        check_mixed_integer_constraints(self, dut, autonomous=True)
+        result = dut.mixed_integer_constraints()
+        self.assertIsNone(result.Aout_input)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([1.2, 0.3, 0.5], dtype=dut.dtype),
+            u_val=None, autonomous=True)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([0.2, 0.5, -0.5], dtype=dut.dtype),
+            u_val=None, autonomous=True)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([-0.4, 0.9, -0.5], dtype=dut.dtype),
+            u_val=None, autonomous=True)
 
     def test_equilibrium(self):
         dut, x_equ = self.construct_relu_system_example()
@@ -314,7 +429,15 @@ class TestAutonomousResidualReLUSystemGivenEquilibrium(unittest.TestCase):
         dut, _ = self.construct_relu_system_example()
 
         self.assertEqual(dut.x_dim, 3)
-        check_mixed_integer_constraints(self, dut, autonomous=True)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([1.2, 0.3, 0.5], dtype=dut.dtype),
+            u_val=None, autonomous=True)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([0.2, 0.5, -0.5], dtype=dut.dtype),
+            u_val=None, autonomous=True)
+        check_mixed_integer_constraints(
+            self, dut, x_val=torch.tensor([-0.4, 0.9, -0.5], dtype=dut.dtype),
+            u_val=None, autonomous=True)
 
     def test_equilibrium(self):
         dut, x_equ = self.construct_relu_system_example()


### PR DESCRIPTION
When we know the dynamics is second order, we don't need to learn the update on `q`. Because `qdot = v`, this part of the dynamics doesn't depend on the data. Create a class that only use the neural network to represent the update for the second order dynamics (update for `v` part).