### PR TITLE
Add the most recent adversarial samples to the training set.

### DIFF
--- a/neural_network_lyapunov/examples/pendulum/train_pendulum_demo.py
+++ b/neural_network_lyapunov/examples/pendulum/train_pendulum_demo.py
@@ -302,10 +302,10 @@ if __name__ == "__main__":
     # Now train the controller and Lyapunov function together
     q_equilibrium = torch.tensor([np.pi], dtype=torch.float64)
     u_equilibrium = torch.tensor([0], dtype=torch.float64)
-    x_lo = torch.tensor([np.pi - 1.2 * np.pi, -5.], dtype=torch.float64)
-    x_up = torch.tensor([np.pi + 1.2 * np.pi, 5.], dtype=torch.float64)
-    u_lo = torch.tensor([-12], dtype=torch.float64)
-    u_up = torch.tensor([12], dtype=torch.float64)
+    x_lo = torch.tensor([np.pi - 0.7 * np.pi, -3.], dtype=torch.float64)
+    x_up = torch.tensor([np.pi + 0.7 * np.pi, 3.], dtype=torch.float64)
+    u_lo = torch.tensor([-20], dtype=torch.float64)
+    u_up = torch.tensor([20], dtype=torch.float64)
     forward_system = relu_system.ReLUSecondOrderSystemGivenEquilibrium(
         torch.float64, x_lo, x_up, u_lo, u_up, dynamics_model, q_equilibrium,
         u_equilibrium, dt)
@@ -329,7 +329,7 @@ if __name__ == "__main__":
     dut.lyapunov_derivative_convergence_tol = 1E-5
     dut.max_iterations = args.max_iterations
     dut.lyapunov_positivity_epsilon = 0.5
-    dut.lyapunov_derivative_epsilon = 0.004
+    dut.lyapunov_derivative_epsilon = 0.001
     dut.lyapunov_derivative_eps_type = lyapunov.ConvergenceEps.ExpLower
     state_samples_all = utils.get_meshgrid_samples(
         x_lo, x_up, (51, 51), dtype=torch.float64)
@@ -340,5 +340,9 @@ if __name__ == "__main__":
             batch_size=50)
 
     dut.enable_wandb = args.enable_wandb
+    dut.add_derivative_adversarial_state = True
+    dut.lyapunov_derivative_mip_cost_weight = 0.
+    dut.add_positivity_adversarial_state = True
+    dut.lyapunov_positivity_mip_cost_weight = 0.
     dut.train(torch.empty((0, 2), dtype=torch.float64))
     pass

--- a/neural_network_lyapunov/test/test_train_lyapunov.py
+++ b/neural_network_lyapunov/test/test_train_lyapunov.py
@@ -165,17 +165,17 @@ class TestTrainLyapunovReLU(unittest.TestCase):
         loss_expected += dut.lyapunov_positivity_sample_cost_weight *\
             lyapunov_hybrid_system.lyapunov_positivity_loss_at_samples(
                 relu_at_equilibrium, x_equilibrium,
-                state_samples_all[-dut.max_sample_pool_size:], V_lambda,
-                dut.lyapunov_positivity_epsilon,
+                positivity_state_samples_new[-dut.max_sample_pool_size:],
+                V_lambda, dut.lyapunov_positivity_epsilon,
                 R=R_options.R(), margin=dut.lyapunov_positivity_sample_margin)
         loss_expected += dut.lyapunov_derivative_sample_cost_weight *\
             lyapunov_hybrid_system.\
             lyapunov_derivative_loss_at_samples_and_next_states(
                 V_lambda, dut.lyapunov_derivative_epsilon,
-                state_samples_all[-dut.max_sample_pool_size:],
-                state_samples_next[-dut.max_sample_pool_size:], x_equilibrium,
-                dut.lyapunov_derivative_eps_type, R=R_options.R(),
-                margin=dut.lyapunov_derivative_sample_margin)
+                derivative_state_samples_new[-dut.max_sample_pool_size:],
+                derivative_state_samples_next_new[-dut.max_sample_pool_size:],
+                x_equilibrium, dut.lyapunov_derivative_eps_type,
+                R=R_options.R(), margin=dut.lyapunov_derivative_sample_margin)
         lyapunov_positivity_mip_return = lyapunov_hybrid_system.\
             lyapunov_positivity_as_milp(
                 x_equilibrium, V_lambda, dut.lyapunov_positivity_epsilon,


### PR DESCRIPTION
I compared the runtime and number of iterations between using only adversarial samples and only with bilevel optimization, on different x_lo, x_up for the pendulum

Runtime:
| run  | Adversarial | BiLevel |
| ------| ---------------| -----------|
| 1     |       548s     | 2823s   |
| 2     |  78s            |    165s  |

Number of iterations
| run  | Adversarial | BiLevel |
|-------| ----------------| -----------|
| 1     |       984       | 3307     |
| 2     |    294          |  297      |

I don't know whether the advantage of adversarial training over bilevel optimization can translate to other tasks, like dubins car or quadrotor, but it's worth trying out.